### PR TITLE
fix: Fix JDK-17 Upgrade When Generating Captcha - MEED-1394

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ LABEL   maintainer="Meeds <docker@exoplatform.com>"
 # Install the needed packages
 RUN apt-get update \
     && apt-get -y upgrade ${_APT_OPTIONS} \
-    && apt-get -y install ${_APT_OPTIONS} xmlstarlet \
+    && apt-get -y install ${_APT_OPTIONS} xmlstarlet fontconfig fontconfig-config \
     && apt-get -y autoremove \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Prior to this change, the captcha wasn't generated any more on registration form, the raised error is  and . This change will install missing font configuration packages in order to install OS Font libraries to be able to use it in Captcha Generation.